### PR TITLE
FIX: add release prefix to create tags during binary deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true
-          tag_name: ${{ github.ref_name }}
+          tag_name: release-${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -195,7 +195,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
+          tag_name: release-${{ github.ref_name }}
           fail_on_unmatched_files: true
           files: |
             artifacts/Optimus_*_Linux.zip


### PR DESCRIPTION
A fix to tag names to generate a release with binary files 